### PR TITLE
refactor custom installation directory command example

### DIFF
--- a/docs/tutorials/bash.md
+++ b/docs/tutorials/bash.md
@@ -25,7 +25,7 @@ During the first run of `pglet.sh` Pglet binary will be downloaded to `$HOME/.pg
 If you want to install Pglet binary into a custom directory you can define `PGLET_INSTALL_DIR` environment variable. For example to install Pglet binary to `/usr/local/bin` directory run:
 
 ```bash
-PGLET_INSTALL_DIR=/usr/local/bin sudo bash pglet.sh
+export PGLET_INSTALL_DIR=/usr/local/bin && sudo bash pglet.sh
 ```
 
 :::note


### PR DESCRIPTION
the `` export `` command should be used to pass the variable into the environment of the script.
I would separate setting of environment variable and script command to avoid error when using export:
`` bash: export: `pglet.sh': not a valid identifier ``